### PR TITLE
Use HTTPS to download certdata.txt from Mozilla project.

### DIFF
--- a/gencerts/gencerts.go
+++ b/gencerts/gencerts.go
@@ -39,7 +39,7 @@ import (
 )
 
 const (
-	defaultDownloadURL = "http://hg.mozilla.org/releases/mozilla-release/raw-file/default/security/nss/lib/ckfw/builtins/certdata.txt"
+	defaultDownloadURL = "https://hg.mozilla.org/releases/mozilla-release/raw-file/default/security/nss/lib/ckfw/builtins/certdata.txt"
 )
 
 var (


### PR DESCRIPTION
Maybe use HTTPS is more correspond with this project :) .